### PR TITLE
Update_to_langchain_1.0

### DIFF
--- a/backend/pike.py
+++ b/backend/pike.py
@@ -2,10 +2,7 @@ import contextlib as cl
 import fastapi as fapi
 import fastapi.middleware.cors as fapi_cors
 import routes as routes
-import dotenv as de
-import src.pike_util as pike_util
-import os
-     
+
 
 @cl.asynccontextmanager
 async def service_lifecycle(app: fapi.FastAPI):

--- a/backend/src/model.py
+++ b/backend/src/model.py
@@ -3,8 +3,8 @@ from typing import Dict, Optional
 import uuid
 import langchain_google_genai as lgai
 import langchain_openai as loai
-import src.pike_util as pike_util
-import src.pike_defaults as pike_defaults
+import src.pike_util as util
+import src.pike_defaults as defaults
 
 # Global cache for model instances
 global MODEL_CACHE
@@ -31,14 +31,14 @@ class Model(pdc.BaseModel):
             # Create Google model instance
             raw_model = lgai.ChatGoogleGenerativeAI(
                 model=self.name,
-                google_api_key=pike_util.extract_environ_var("GOOGLE_API_KEY"),
+                google_api_key=util.extract_environ_var("GOOGLE_API_KEY"),
                 **self.additional_kwargs
             )
         elif self.provider.lower() == "openai":
             # Create OpenAI model instance
             raw_model = loai.ChatOpenAI(
                 model=self.name,
-                api_key=pike_util.extract_environ_var("OPENAI_API_KEY"),
+                api_key=util.extract_environ_var("OPENAI_API_KEY"),
                 **self.additional_kwargs
             )
         else:
@@ -51,19 +51,19 @@ class Model(pdc.BaseModel):
 
 
 def create_default_model():
-    provider = pike_defaults.provider
+    provider = defaults.provider
     if provider == "google":
         return Model(
             provider="google",
             name="gemini-2.0-flash",
-            api_key=pike_util.extract_environ_var("GOOGLE_API_KEY"),
+            api_key=util.extract_environ_var("GOOGLE_API_KEY"),
             additional_kwargs={}
         )
     elif provider == "openai":
         return Model(
             provider="openai",
             name="gpt-4o-mini",
-            api_key=pike_util.extract_environ_var("OPENAI_API_KEY"),
+            api_key=util.extract_environ_var("OPENAI_API_KEY"),
             additional_kwargs={}
         )
     else:

--- a/backend/src/pike_defaults.py
+++ b/backend/src/pike_defaults.py
@@ -1,12 +1,12 @@
 import os
-import src.pike_util as pike_util
+import src.pike_util as util
 
 if os.environ.get("DEFAULT_MODEL_PROVIDER"):
     provider = os.environ.get("DEFAULT_MODEL_PROVIDER")
 else:
-    provider = pike_util.extract_environ_var("DEFAULT_MODEL_PROVIDER")
+    provider = util.extract_environ_var("DEFAULT_MODEL_PROVIDER")
 
 if os.environ.get("DEFAULT_DOMAIN"):
     domain = os.environ.get("DEFAULT_DOMAIN")
 else:
-    domain = pike_util.extract_environ_var("DEFAULT_DOMAIN")
+    domain = util.extract_environ_var("DEFAULT_DOMAIN")

--- a/backend/src/pike_tool.py
+++ b/backend/src/pike_tool.py
@@ -6,7 +6,7 @@ import urllib
 import os
 import importlib as il
 import uuid as u
-import src.pike_defaults as pike_defaults
+import src.pike_defaults as defaults
 import inspect
 
 def get_icons_path() -> str:
@@ -66,10 +66,10 @@ class PikeTool(lct.BaseTool):
         self.llm = llm
 
     def model_post_init(self, __context=None):
-        default_domain = pike_defaults.domain
+        default_domain = defaults.domain
         if default_domain is None:
             default_domain = "nothing.nowhere.com"
-        self.id = u.uuid5(u.uuid5(u.NAMESPACE_DNS, pike_defaults.domain), self.name)
+        self.id = u.uuid5(u.uuid5(u.NAMESPACE_DNS, defaults.domain), self.name)
 
     def _call(self, *args, **kwargs):
         """

--- a/backend/tests/test_parse_pdf.py
+++ b/backend/tests/test_parse_pdf.py
@@ -25,7 +25,7 @@ def test_parse_pdf_reads_content(monkeypatch, generate_test_pdf_bytes):
     monkeypatch.setattr(pf, "get_pdf_attachment",
                         lambda _: io.BytesIO(pdf_binary))
 
-    content = pf.parse_pdf("fake-uuid-1234")
+    content = pf.parse_pdf.invoke("fake-uuid-1234")
 
     assert isinstance(content, str)
     assert "Hello World" in content
@@ -41,4 +41,4 @@ def test_parse_pdf_invalid_attachment(monkeypatch):
     )
 
     with pytest.raises(FileNotFoundError):
-        pf.parse_pdf("non-existent-uuid")
+        pf.parse_pdf.invoke("non-existent-uuid")

--- a/backend/tests/test_tool_summaries.py
+++ b/backend/tests/test_tool_summaries.py
@@ -44,7 +44,7 @@ def mock_dependencies(monkeypatch):
 
 def test_summarize_text_mocked(mock_dependencies):
     input_text = "Artificial Intelligence is transforming the world."
-    output = su.summarize_text(input_text)
+    output = su.summarize_text.invoke(input_text)
 
     expected_prompt = f"Summarize: {input_text}"
     assert mock_dependencies['prompt'] == expected_prompt
@@ -55,6 +55,6 @@ def test_summarize_text_mocked(mock_dependencies):
 @pytest.mark.skip_in_pipeline
 def test_summarize_text_real():
     input_text = "Artificial Intelligence is changing global industries with automation, data analysis, and decision-making support."
-    output = su.summarize_text(input_text)
+    output = su.summarize_text.invoke(input_text)
 
     assert isinstance(output, str)

--- a/backend/tests/test_webpage_parsing.py
+++ b/backend/tests/test_webpage_parsing.py
@@ -54,7 +54,7 @@ def test_parse_webpage_returns_all_test_texts(
         patch_httpurl_accepts_file
 ):
     # Patch requests.get to read the local file instead of making an HTTP request
-    result = wp.parse_webpage(local_test_page_url)
+    result = wp.parse_webpage.invoke(local_test_page_url)
     test_texts = [f'Test_Text_{i}' for i in range(1, 12)] # List of texts expected to be extracted from test_page.html
     for text in test_texts:
         assert text in result, f"{text} not found in parsed content"
@@ -65,23 +65,23 @@ def test_parse_webpage_ignores_scripts(
         patch_httpurl_accepts_file
 ):
     # Patch requests.get to read the local file instead of making an HTTP request
-    result = wp.parse_webpage(local_test_page_url)
+    result = wp.parse_webpage.invoke(local_test_page_url)
     assert 'Test_Text_12' not in result, f"Test_Text_12 should not be found in parsed content"
 
 def test_parse_webpage_raises_for_nonexistent_url():
     non_existent_url = 'http://www.google.com/thisisnotarealpageandthereforedoesnotexist.html'
     with pytest.raises(requests.HTTPError):
-        wp.parse_webpage(non_existent_url)
+        wp.parse_webpage.invoke(non_existent_url)
 
 def test_parse_webpage_raises_for_wrong_url_scheme():
     wrong_url = 'ftp://example.com/test_page.html'
     with pytest.raises(pyd.ValidationError):
-        wp.parse_webpage(wrong_url)
+        wp.parse_webpage.invoke(wrong_url)
 
 def test_parse_webpage_raises_for_unsanitizable_url():
     unsanitizable_url = 'http://:80'
     with pytest.raises(pyd.ValidationError):
-        wp.parse_webpage(unsanitizable_url)
+        wp.parse_webpage.invoke(unsanitizable_url)
 
 def test_host_resolvable_raises_for_unresolvable_host():
     unresolvable_url = 'http://unresolvable.host'
@@ -91,4 +91,4 @@ def test_host_resolvable_raises_for_unresolvable_host():
 def test_unresolvable_shortcircuits_request():
     unresolvable_url = 'http://unresolvable.host'
     with pytest.raises(socket.gaierror):
-        wp.parse_webpage(unresolvable_url)
+        wp.parse_webpage.invoke(unresolvable_url)


### PR DESCRIPTION
Langchain 1.0 changed how we should directly invoke tools (e.g. for testing) so I have updated the tests to reflect the proper invocation approach.  Also fixed some internal naming bits that were unnecessarily long.